### PR TITLE
[Fix] Add support for gzip compressed SSE streams.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,9 +110,9 @@ System.getProperty("ucs.includeDbgSymbols", "false")))
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-def enforcePmd = true
+def enforceStaticAnalysis = includeDbgSymbols
 def pmdScanLevel = 2
-def enforceJacoco = includeDbgSymbols
+def enforceCodeCoverage = includeDbgSymbols
 import java.time.Instant
 def thisYear = Instant.now().toDate().toYear().toString()
 
@@ -230,7 +230,7 @@ subprojects {
         group = "Reporting"
         consoleOutput = true
         rulePriority = pmdScanLevel
-        ignoreFailures = !enforcePmd
+        ignoreFailures = !enforceStaticAnalysis
         ruleSets = []
         ruleSetFiles = files("${rootProject.projectDir}/pmd.xml")
         reports {
@@ -267,7 +267,7 @@ subprojects {
         }
         effort = 'default'
         reportLevel = 'medium'
-        ignoreFailures = false
+        ignoreFailures = !enforceStaticAnalysis
         excludeFilter = file("${rootProject.projectDir}/findBugsExclusions.xml")
     }
 
@@ -312,14 +312,14 @@ project(':xdg') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -336,14 +336,14 @@ project(':properties') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -362,14 +362,14 @@ project(':logging') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -388,14 +388,14 @@ project(':runtime_utils') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -417,14 +417,14 @@ project(':config_io') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -452,14 +452,14 @@ project(':procedures') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -484,14 +484,14 @@ project(':authentication') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -518,14 +518,14 @@ project(':networking') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -573,14 +573,14 @@ project(':dai_core') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.81
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.52
@@ -627,14 +627,14 @@ project(':ui') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -678,14 +678,14 @@ project(':populate_schema') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -719,14 +719,14 @@ project(':dai_network_listener') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -752,14 +752,14 @@ project(":provisioners") {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -787,14 +787,14 @@ project(":inventory") {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.61
@@ -823,14 +823,14 @@ project(":inventory_api") {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.61
@@ -856,14 +856,14 @@ project(":monitoring") {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -887,14 +887,14 @@ project(":ras") {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -910,14 +910,14 @@ project(':perflogging') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -951,14 +951,14 @@ project(':foreign_bus') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -997,14 +997,14 @@ project(':resource_managers') {
     jacocoTestCoverageVerification {
         violationRules {
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'METHOD'
                     minimum = 0.90
                 }
             }
             rule {
-                enabled = enforceJacoco
+                enabled = enforceCodeCoverage
                 limit {
                     counter = 'BRANCH'
                     minimum = 0.70
@@ -1685,6 +1685,9 @@ exit \$?
     from ("${projectDir}/docker-deploy/dai.yml") {
         into("opt/dai-docker")
     }
+    from ("${projectDir}/docker-deploy/test_app.yml") {
+        into("opt/dai-docker")
+    }
     from("${buildDir}/jars") {
         exclude("**/procedures-${packageVersion}.jar")
         exclude("**/populate_schema-${packageVersion}.jar")
@@ -1702,6 +1705,10 @@ exit \$?
         into("opt/dai-docker/etc")
     }
     from("${projectDir}/docker-deploy/dai/entryPoint.sh") {
+        into("opt/dai-docker/dai")
+        fileMode = 0700
+    }
+    from("${projectDir}/docker-deploy/dai/testEntryPoint.sh") {
         into("opt/dai-docker/dai")
         fileMode = 0700
     }

--- a/dai_network_listener/src/main/java/com/intel/dai/network_listener/NetworkListenerConfig.java
+++ b/dai_network_listener/src/main/java/com/intel/dai/network_listener/NetworkListenerConfig.java
@@ -32,7 +32,8 @@ public class NetworkListenerConfig {
         adapter_ = adapter;
         parser_ = ConfigIOFactory.getInstance("json");
         if(parser_ == null) throw new RuntimeException("Failed to get a JSON parser"); // Cannot happen, for compile
-        useDebugPrint_ = Boolean.valueOf(System.getProperty(this.getClass().getCanonicalName() + ".DEBUG", "false"));
+        useDebugPrint_ = Boolean.parseBoolean(System.getProperty(this.getClass().getCanonicalName() + ".DEBUG",
+                "false"));
     }
 
     public void loadFromStream(InputStream stream) throws IOException, ConfigIOParseException {

--- a/findBugsExclusions.xml
+++ b/findBugsExclusions.xml
@@ -30,6 +30,10 @@
         <Bug code="DE" />
     </Match>
     <Match> <!-- False positive -->
+        <Class name="com.intel.networking.restclient.apache.ApacheRESTClient" />
+        <Bug code="RCN" />
+    </Match>
+    <Match> <!-- False positive -->
         <Class name="com.intel.dai.ras.AdapterRasForeignBus" />
         <Method name="fillInRasEventsWithMissingJobId" />
         <Bug code="DLS" />
@@ -138,7 +142,7 @@
     **************************************************************************************************************-->
 
     <Match> <!-- TODO: This is technically an issue, it will need to be resolved in the future -->
-        <Class name="com.intel.networking.restclient.java11.Java11RESTClient$1" />
+        <Class name="com.intel.networking.restclient.PermissiveX509TrustManager" />
         <Bug code="SECWTM" />
     </Match>
     <Match> <!-- TODO: This should be fixed at some point, the code is WIP -->

--- a/networking/src/main/java/com/intel/networking/restclient/EventSource.java
+++ b/networking/src/main/java/com/intel/networking/restclient/EventSource.java
@@ -1,0 +1,40 @@
+// Copyright (C) 2020 Paul Amonson
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package com.intel.networking.restclient;
+
+/**
+ * Description for class EventSource
+ */
+public class EventSource {
+    public void processLine(String line, SSEEvent eventsCallback) {
+        if (line.startsWith(":"))
+            return;
+        if(line.isBlank()) { // do dispatch...
+            if(data.isBlank()) { // empty event; reset and abort
+                reset();
+                return;
+            }
+            if(eventsCallback != null)
+                eventsCallback.event(event, data, id);
+            reset();
+        }
+        else if (line.startsWith("event:"))
+            event = line.substring(6).trim();
+        else if(line.startsWith("data:"))
+            data += line.substring(5).trim();
+        else if(line.startsWith("id:"))
+            id = line.substring(3).trim();
+    }
+
+    private void reset() {
+        event = "";
+        data = "";
+    }
+
+    private String event = "";
+    private String data = "";
+    private String id = null;
+}

--- a/networking/src/main/java/com/intel/networking/restclient/PermissiveX509TrustManager.java
+++ b/networking/src/main/java/com/intel/networking/restclient/PermissiveX509TrustManager.java
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+package com.intel.networking.restclient;
+
+import javax.net.ssl.X509TrustManager;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+/**
+ * Description of class PermissiveX509TrustManager.
+ */
+public class PermissiveX509TrustManager implements X509TrustManager {
+    @Override public void checkClientTrusted(X509Certificate[] x509Certificates, String s)
+            throws CertificateException { }
+
+    @Override public void checkServerTrusted(X509Certificate[] x509Certificates, String s)
+            throws CertificateException { }
+
+    @Override public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+}

--- a/networking/src/main/java/com/intel/networking/restclient/RESTClientFactory.java
+++ b/networking/src/main/java/com/intel/networking/restclient/RESTClientFactory.java
@@ -84,5 +84,6 @@ public final class RESTClientFactory {
 
     static final Map<String, Class<? extends RESTClient>> implementations_ = new HashMap<>() {{
         put("jdk11", com.intel.networking.restclient.java11.Java11RESTClient.class);
+        put("apache", com.intel.networking.restclient.apache.ApacheRESTClient.class);
     }};
 }

--- a/networking/src/main/java/com/intel/networking/restclient/apache/ApacheRESTClient.java
+++ b/networking/src/main/java/com/intel/networking/restclient/apache/ApacheRESTClient.java
@@ -1,0 +1,198 @@
+// Copyright (C) 2020 Paul Amonson
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+package com.intel.networking.restclient.apache;
+
+import com.intel.logging.Logger;
+import com.intel.networking.restclient.*;
+import org.apache.http.*;
+import org.apache.http.client.methods.*;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Map;
+
+/**
+ * Description of class ApacheRESTClient. This REST client uses permissive SSL (trusts ALL certificates and host names).
+ * To change to exclusive certificate, use the default SSLContext object and create a keystore for Java with
+ * the certificate in the store. Then point the SSLContext to the new keystore. This will limit the REST
+ * client to communicate with ONLY the server using the certificate specified. All other SSL connections will
+ * fail.
+ *
+ * This class is still backward compatible with regular non-SSL HTTP.
+ */
+public class ApacheRESTClient extends RESTClient {
+    /**
+     * Called by derived classes only to construct this parent implementation.
+     *
+     * @param log The logger to use.
+     */
+    public ApacheRESTClient(Logger log) {
+        super(log);
+        try { // This SSLContext accepts ALL certificates and should NEVER be used to talk to the internet!!!
+            SSLContext context = SSLContext.getInstance("TLS");
+            TrustManager[] tm = new TrustManager[] { new PermissiveX509TrustManager() };
+            context.init(null, tm, new SecureRandom());
+            client_ = HttpClientBuilder.create().
+                    setSSLContext(context).
+                    setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE).
+                    build();
+        } catch(NoSuchAlgorithmException | KeyManagementException e) {
+            throw new RuntimeException("Failed to setup permissive SSL connection", e);
+        }
+    }
+
+    /**
+     * Called by the subscribeToSSE method after the SSERequestBuilder has converted the event types list to a
+     * PropertyDocument body. This MUST be implemented by the RESTClient implementation.
+     *
+     * @param request        The RequestInfo to make the SSE subscription request.
+     * @param callback       Called when the initial HTTP response is sent from the server.
+     * @param eventsCallback Called for every non-comment event that is sent.
+     */
+    @Override
+    protected void doSSERequest(RequestInfo request, ResponseCallback callback, SSEEvent eventsCallback) {
+        HttpGet methodRequest = new HttpGet(request.uri());
+        log_.debug("*** SSE Request: uri='%s'", request.uri());
+        try {
+            client_.execute(methodRequest, (response) -> {
+                for(Header header: response.getAllHeaders())
+                    log_.debug("HEADER: %s: %s", header.getName(), header.getValue());
+                int code = response.getStatusLine().getStatusCode();
+                if(code >= 200 && code < 300) {
+                    callback.responseCallback(code, null, request);
+                    try (Reader baseReader = new InputStreamReader(response.getEntity().getContent(),
+                            StandardCharsets.UTF_8)) {
+                        try (LineNumberReader reader = new LineNumberReader(baseReader)) {
+                            String line = reader.readLine();
+                            while(line != null) {
+                                event_.processLine(line, eventsCallback);
+                                line = reader.readLine();
+                            }
+                        }
+                    } finally {
+                        log_.debug("*** Closing the content stream #1...");
+                        response.getEntity().getContent().close();
+                    }
+                } else {
+                    callback.responseCallback(code, streamToBody(response.getEntity().getContent()), request);
+                    log_.debug("*** Closing the content stream #2...");
+                    response.getEntity().getContent().close();
+                }
+                return null;
+            });
+        } catch(IOException e) {
+            log_.exception(e, "Failed to create SSE connection!");
+            callback.responseCallback(-1, exceptionToString(e), request);
+        }
+    }
+
+    /**
+     * Called by ALL REST methods (not SSE) to do the actual HTTP request.
+     *
+     * @param request The RequestInfo for the request.
+     * @return The blocking result.
+     */
+    @Override
+    protected BlockingResult doRESTRequest(RequestInfo request) {
+        HttpRequestBase methodRequest = makeRequest(request);
+        log_.debug("*** REST Request: method='%s'; uri='%s'; body='%s'", request.method(), request.uri(),
+                request.body());
+        try (CloseableHttpResponse response = client_.execute(methodRequest)) {
+            try (InputStreamReader reader = new InputStreamReader(response.getEntity().getContent(),
+                    StandardCharsets.UTF_8)) {
+                StringWriter writer = new StringWriter();
+                reader.transferTo(writer);
+                return new BlockingResult(response.getStatusLine().getStatusCode(), writer.toString(), request);
+            }
+        } catch (IOException e) {
+            log_.exception(e);
+            return new BlockingResult(-1, exceptionToString(e), request);
+        }
+    }
+
+    private String streamToBody(InputStream stream) throws IOException {
+        try (InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+            StringWriter writer = new StringWriter();
+            reader.transferTo(writer);
+            return writer.toString();
+        }
+    }
+
+    private String exceptionToString(Exception e) {
+        StringBuilder builder = new StringBuilder();
+        makeException(e, builder);
+        return builder.toString();
+    }
+
+    void makeException(Throwable e, StringBuilder builder) {
+        builder.append("Exception: ").append(e.getClass().getCanonicalName()).append(": ").append(e.getMessage()).
+                append("\n");
+        makeTrace(e, builder);
+        if(e.getCause() != null) {
+            builder.append("Caused by ");
+            makeException(e.getCause(), builder);
+        }
+    }
+
+    private void makeTrace(Throwable exception, StringBuilder builder) {
+        for(StackTraceElement element: exception.getStackTrace())
+            builder.append("   ").append(element.toString()).append("\n");
+    }
+
+    private HttpRequestBase makeRequest(RequestInfo info) {
+        HttpRequestBase result;
+        switch(info.method()) {
+            case GET:
+            default:
+                result = new HttpGet(info.uri());
+                break;
+            case HEAD:
+                result = new HttpHead(info.uri());
+                break;
+            case POST:
+                result = new HttpPost(info.uri());
+                break;
+            case PUT:
+                result = new HttpPut(info.uri());
+                break;
+            case DELETE:
+                result = new HttpDelete(info.uri());
+                break;
+            case OPTIONS:
+                result = new HttpOptions(info.uri());
+                break;
+            case PATCH:
+                result = new HttpPatch(info.uri());
+                break;
+        }
+        for(Map.Entry<String,String> entry: info.headers().entrySet())
+            result.addHeader(entry.getKey(), entry.getValue());
+        if(info.body() != null && !info.body().isBlank() && result instanceof HttpEntityEnclosingRequestBase) {
+            if(!info.headers().containsKey("Content-Type"))
+                result.addHeader("Content-Type", "application/json");
+            try {
+                ((HttpEntityEnclosingRequestBase) result).setEntity(new StringEntity(info.body()));
+            } catch (UnsupportedEncodingException e) {
+                log_.exception(e);
+            }
+        }
+        return result;
+    }
+
+    private EventSource event_ = new EventSource();
+    private CloseableHttpClient client_;
+}

--- a/networking/src/main/java/com/intel/networking/sink/restsse/NetworkDataSinkSSE.java
+++ b/networking/src/main/java/com/intel/networking/sink/restsse/NetworkDataSinkSSE.java
@@ -29,7 +29,7 @@ public class NetworkDataSinkSSE implements NetworkDataSink {
      * @param args The arguments to the publisher. Supported argument keys are:
      *
      *   parser            - (def: "json")      The payload parser to use, mainly for SSE's "id:" tag.
-     *   implementation    - (def: "jdk11")     The implementation for the REST client.
+     *   implementation    - (def: "apache")    The implementation for the REST client.
      *   connectAddress    - (def: "127.0.0.1") The address to connect to.
      *   connectPort       - (def: 19216)       The port to connect to.
      *   urlPath           - (def: "/restsse/") The url path to send subscription request to.
@@ -62,7 +62,7 @@ public class NetworkDataSinkSSE implements NetworkDataSink {
         uri_ = URI.create(String.format("http%s://%s:%d%s", ssl, args_.getOrDefault("connectAddress", "127.0.0.1"),
                 Integer.parseInt(args_.getOrDefault("connectPort", "19216")),
                 args_.getOrDefault("urlPath", "/restsse/")));
-        implementation_ = args_.getOrDefault("implementation", "jdk11");
+        implementation_ = args_.getOrDefault("implementation", "apache");
         if(args_.getOrDefault("requestBuilder", null) != null) {
             createBuilder(args_.getOrDefault("requestBuilder", null));
             if(builder_ == null) throw new NetworkException("Failed to create a network REST request builder");

--- a/networking/src/test/groovy/com/intel/networking/restclient/PermissiveX509TrustManagerSpec.groovy
+++ b/networking/src/test/groovy/com/intel/networking/restclient/PermissiveX509TrustManagerSpec.groovy
@@ -1,0 +1,24 @@
+package com.intel.networking.restclient
+
+import spock.lang.Specification
+
+class PermissiveX509TrustManagerSpec extends Specification {
+    def underTest_
+    void setup() {
+        underTest_ = new PermissiveX509TrustManager()
+    }
+
+    def "Test CheckClientTrusted"() {
+        underTest_.checkClientTrusted(null, null)
+        expect: true
+    }
+
+    def "Test CheckServerTrusted"() {
+        underTest_.checkServerTrusted(null, null)
+        expect: true
+    }
+
+    def "Test GetAcceptedIssuers"() {
+        expect: underTest_.getAcceptedIssuers().length == 0
+    }
+}

--- a/networking/src/test/groovy/com/intel/networking/restclient/apache/ApacheRESTClientSpec.groovy
+++ b/networking/src/test/groovy/com/intel/networking/restclient/apache/ApacheRESTClientSpec.groovy
@@ -1,0 +1,90 @@
+package com.intel.networking.restclient.apache
+
+import com.intel.logging.Logger
+import com.intel.networking.HttpMethod
+import com.intel.networking.restclient.RequestInfo
+import com.intel.networking.restclient.ResponseCallback
+import com.intel.networking.restclient.SSEEvent
+import org.apache.http.HttpEntity
+import org.apache.http.StatusLine
+import org.apache.http.client.methods.CloseableHttpResponse
+import org.apache.http.client.methods.HttpUriRequest
+import org.apache.http.impl.client.CloseableHttpClient
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class ApacheRESTClientSpec extends Specification implements ResponseCallback, SSEEvent {
+    CloseableHttpClient client_
+    CloseableHttpResponse response_
+    HttpEntity entity_
+    InputStream content_
+    StatusLine status_
+    static URI uri_ = URI.create("http://127.0.0.1:8080/api")
+    static Map<String,String> headers_ = new HashMap() {{
+        put("X-Unknown", "Testing")
+    }}
+
+    def underTest_
+    void setup() {
+        underTest_ = new ApacheRESTClient(Mock(Logger))
+        status_ = GroovyMock(StatusLine)
+        status_.getStatusCode() >> { 200 }
+        content_ = Mock(InputStream)
+        entity_ = GroovyMock(HttpEntity)
+        entity_.getContent() >> { content_ }
+        response_ = GroovyMock(CloseableHttpResponse)
+        response_.getEntity() >> { entity_ }
+        response_.getStatusLine() >> { status_ }
+        client_ = GroovyMock(CloseableHttpClient)
+        client_.execute(_ as HttpUriRequest) >> { response_ }
+        underTest_.client_ = client_
+    }
+
+    @Override
+    void responseCallback(int code, String responseBody, RequestInfo originalInfo) {
+    }
+
+    @Override
+    void event(String eventType, String event, String id) {
+    }
+
+    def "Test DoSSERequest"() {
+        underTest_.doSSERequest(new RequestInfo(HttpMethod.GET,
+                URI.create("http://127.0.0.1:8080/api"), null), this, this)
+        expect: true
+    }
+
+    def "Test DoRESTRequest"() {
+        underTest_.doRESTRequest(new RequestInfo(HttpMethod.GET,
+                URI.create("http://127.0.0.1:8080/api"), null));
+        expect: true
+    }
+
+    def "Test MakeException"() {
+        StringBuilder builder = new StringBuilder()
+        underTest_.makeException(new Exception("testing...", new Exception("cause")), builder)
+        expect: true
+    }
+
+    def "Test StreamToBody"() {
+        ByteArrayInputStream stream = new ByteArrayInputStream("{}".getBytes(StandardCharsets.UTF_8))
+        expect: underTest_.streamToBody(stream) == "{}"
+    }
+
+    def "Test makeRequest"() {
+        given:
+        underTest_.makeRequest(INFO)
+
+        expect: EXPECTED
+
+        where:
+        INFO                                                      | EXPECTED
+        new RequestInfo(HttpMethod.HEAD, uri_, "")                | true
+        new RequestInfo(HttpMethod.POST, uri_, "{}")              | true
+        new RequestInfo(HttpMethod.DELETE, uri_, "", headers_)    | true
+        new RequestInfo(HttpMethod.PUT, uri_, "{}")               | true
+        new RequestInfo(HttpMethod.OPTIONS, uri_, null, headers_) | true
+        new RequestInfo(HttpMethod.PATCH, uri_, "{}")             | true
+    }
+}

--- a/networking/src/test/java/com/intel/networking/restclient/RequestInfoTest.java
+++ b/networking/src/test/java/com/intel/networking/restclient/RequestInfoTest.java
@@ -29,5 +29,11 @@ public class RequestInfoTest {
             put("X-Unknown", "value");
         }};
         RequestInfo info = new RequestInfo(HttpMethod.GET, URI.create("http://localhost"), "Body Text.", headers);
+        assertEquals("com.intel.networking.restclient.RequestInfo instance:\n" +
+                "  method=GET\n" +
+                "  uri=http://localhost\n" +
+                "  body=Body Text.\n" +
+                "  headers:\n" +
+                "    X-Unknown: value\n", info.toString());
     }
 }

--- a/networking/src/test/java/com/intel/networking/restclient/java11/SSELineSubscriberTest.java
+++ b/networking/src/test/java/com/intel/networking/restclient/java11/SSELineSubscriberTest.java
@@ -17,7 +17,7 @@ public class SSELineSubscriberTest {
         eventId_ = null;
         eventData_ = null;
         info_ = mock(RequestInfo.class);
-        subscriber_ = new SSELineSubscriber(info_, this::events, mock(Logger.class));
+        subscriber_ = new SSELineSubscriber(this::events, mock(Logger.class));
     }
 
     private void events(String eventType, String event, String id) {
@@ -55,7 +55,7 @@ public class SSELineSubscriberTest {
 
     @Test
     public void onNextNoCallback() {
-        subscriber_ = new SSELineSubscriber(info_, null, mock(Logger.class));
+        subscriber_ = new SSELineSubscriber(null, mock(Logger.class));
         commonMessageStream();
     }
 


### PR DESCRIPTION
Signed-off-by: Paul Amonson <paulamonson@gmail.com>

This adds an Apache HttpComponents based RESTClient implementation and makes it the default for the NetworkDataSinkSSE implementation. Now the SSE stream can be compressed with gzip or deflate.