### PR TITLE
[Fix] Small fix to dai-manager start scripts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2065,7 +2065,7 @@ set -x
 [[ -z "\${DAI_LOGGING_LEVEL}" ]] && DAI_LOGGING_LEVEL=DEBUG
 
 MACHINECONFIG=${etc_dir}/MachineConfig.json
-HOSTNAME=\$(hostname)
+HOSTNAME=\$(hostname -A | awk '{print \$1}')
 VOLTSERVERS=\$(cat ${etc_dir}/volt.ip)
 CLASS="com.intel.dai.AdapterDaiMgr"
 LOCATION=\$(/opt/voltdb/bin/sqlcmd --servers="\${VOLTSERVERS}" --output-skip-metadata --query="select lctn from servicenode where hostname='\${HOSTNAME}';" | sed 's/[\\n ]*//g')
@@ -2200,7 +2200,7 @@ set -x
 [[ -z "\${DAI_LOGGING_LEVEL}" ]] && DAI_LOGGING_LEVEL=DEBUG
 
 MACHINECONFIG=${etc_dir}/MachineConfig.json
-HOSTNAME=\$(hostname)
+HOSTNAME=\$(hostname -A | awk '{print \$1}')
 VOLTSERVERS=\$(cat ${etc_dir}/volt.ip)
 CLASS="com.intel.dai.AdapterDaiMgr"
 LOCATION=\$(/opt/voltdb/bin/sqlcmd --servers="\${VOLTSERVERS}" --output-skip-metadata --query="select lctn from servicenode where hostname='\${HOSTNAME}';" | sed 's/[\\n ]*//g')


### PR DESCRIPTION
Signed-off-by: Paul Amonson <paul.d.amonson@intel.com>

This forces "hostname" to include the FQDN.
