### PR TITLE
Revert "[Fix] Make voltdb work after a reboot in the cleanup script."

### DIFF
--- a/cleanup_machine.sh
+++ b/cleanup_machine.sh
@@ -43,7 +43,3 @@ sudo rm -rf /opt/dai-docker
 sudo rm -rf /opt/ucs
 
 sudo hostname am01-nmn.local
-
-# Setup huge pages correctly for volt in case of a reboot...
-sudo echo never >/sys/kernel/mm/transparent_hugepage/enabled
-sudo echo never >/sys/kernel/mm/transparent_hugepage/defrag


### PR DESCRIPTION
This reverts commit a1dc7d5c8d27f34853325936bafc000473149951.